### PR TITLE
fix(AfterLogicWebmail) perl module installation of YAML::Syck

### DIFF
--- a/cpsetup
+++ b/cpsetup
@@ -686,7 +686,7 @@ function configureMemCachedRailGunSockets(){
 
 function installAfterLogicWebmailLite(){
 	# Make sure 3rd party perl modules is installed
-	perl -MCPAN -e 'install YAML::Syck'
+	cpan YAML::Syck
 	cd $builddir;
 	wget http://www.afterlogic.com/download/webmail-panel-installer.tar.gz
 	tar -xzvf webmail-panel-installer.tar.gz


### PR DESCRIPTION
Fix Error with AfterLogic Webmail installation.
> Can't locate object method "install" via package "YAML::Syck" at -e line 1.

#17 